### PR TITLE
Support non ascii letters

### DIFF
--- a/code/Meerkat.NameParser.Test/Meerkat.NameParser.Test.csproj
+++ b/code/Meerkat.NameParser.Test/Meerkat.NameParser.Test.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net50</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <RootNamespace>Meerkat.Test</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>

--- a/code/Meerkat.NameParser.Test/Meerkat.NameParser.Test.csproj
+++ b/code/Meerkat.NameParser.Test/Meerkat.NameParser.Test.csproj
@@ -1,15 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFramework>net50</TargetFramework>
     <RootNamespace>Meerkat.Test</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <OutputPath>$(SolutionDir)/build/$(Configuration)/$(AssemblyName)/$(TargetFramework)/</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SolutionInfo.cs" Link="Properties\SolutionInfo.cs" />

--- a/code/Meerkat.NameParser.Test/Party/Naming/PersonNameTest.cs
+++ b/code/Meerkat.NameParser.Test/Party/Naming/PersonNameTest.cs
@@ -283,6 +283,12 @@ namespace Meerkat.Test.Party.Naming
             ParseName("Richard The Lionheart", envelope: "Richard The Lionheart", title: "The Lionheart", forename: "Richard");
         }
 
+        [Test]
+        public void NonAsciiCharacters()
+        {
+            ParseName("Øivænd Håøy", envelope: "Øivænd Håøy", forename: "Øivænd", surname: "Håøy");
+        }
+
         private void ParseName(string value, string format = "", string envelope = "", string title = "", string forename = "", string prefix = "", string surname = "", string suffix = "")
         {
             var parser = format == "STF" ? ParserFactory.StandardPersonParser(true) : ParserFactory.StandardPersonParser();

--- a/code/Meerkat.NameParser/Meerkat.NameParser.csproj
+++ b/code/Meerkat.NameParser/Meerkat.NameParser.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net452;net462;net471;net472;netstandard20</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -19,9 +19,9 @@
     <OutDir>$(OutputPath)</OutDir>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Meerkat.Logging" Version="2.2.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Meerkat.Logging" Version="2.3.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG</DefineConstants>

--- a/code/Meerkat.NameParser/Tools/LexExtensions.cs
+++ b/code/Meerkat.NameParser/Tools/LexExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
 
 namespace Meerkat.Tools
 {
@@ -31,7 +32,8 @@ namespace Meerkat.Tools
 
         public static bool IsAlpha(this int value)
         {
-            return value.InLexCharRange(LexChar.A, LexChar.Z) || value.InLexCharRange(LexChar.Alower, LexChar.Zlower);
+            var category = CharUnicodeInfo.GetUnicodeCategory((char)value);
+            return category == UnicodeCategory.LowercaseLetter || category == UnicodeCategory.UppercaseLetter;
         }
 
         public static bool IsAlphaNumeric(this int value)


### PR DESCRIPTION
This package was doing mostly what I needed, except that it was having trouble with some of the Norwegian names we have in our systems. This PR adds support for non-ASCII letters like æ, ø, å.

I also updated Nuget references.